### PR TITLE
Use variable symbol at point as default

### DIFF
--- a/refine.el
+++ b/refine.el
@@ -567,7 +567,10 @@ For booleans, toggle nil/t."
 ;;;###autoload
 (defun refine (symbol)
   "Interactively edit the value of a symbol \(usually a list\)."
-  (interactive (list (read (completing-read "Variable: " (refine--variables)))))
+  (interactive (list (read (completing-read "Variable: " (refine--variables)
+                                            nil nil nil nil
+                                            (-if-let (variable (variable-at-point))
+                                                (and (symbolp variable) (symbol-name variable)))))))
   (let* ((buf (refine--buffer symbol)))
     (refine--update buf symbol)
     (switch-to-buffer buf)


### PR DESCRIPTION
I've started to use refine during development now.  It's very handy.  Thank you!

It would help having the variable at point set as the default when it is invoked.  This seams like the portable method of accomplishing that.

I decided against introducing a helper function, but feel free to re-style if you deem it correct and worth including!  ("Allow edits from maintainers" is enabled, btw)

:+1:
