### PR TITLE
Don’t choke on ‘(repeat number)’ et al.

### DIFF
--- a/test/refine-possible-elements-test.el
+++ b/test/refine-possible-elements-test.el
@@ -26,3 +26,10 @@ that only allows values from a set."
     (refine--possible-elements 'refine--possible-set)
     '(foo bar baz))))
 
+(defcustom refine--possible-unhandled '(1 2 3)
+  "Dummy to make Cask happy."
+  :type '(repeat number))
+
+(ert-deftest refine--possible-elements-unhandled ()
+  "Ensure that unhandled `defcustom' types do not error out."
+  (refine--possible-elements 'refine--possible-unhandled))

--- a/test/refine-possible-elements-test.el
+++ b/test/refine-possible-elements-test.el
@@ -26,6 +26,21 @@ that only allows values from a set."
     (refine--possible-elements 'refine--possible-set)
     '(foo bar baz))))
 
+(defcustom refine--possible-choice '(baz)
+  "Dummy to make Cask happy."
+  :type '(repeat (choice
+                  (const :tag "Foo" foo)
+                  (const :tag "Bar" bar)
+                  (const :tag "Baz" baz))))
+
+(ert-deftest refine--possible-elements-choice ()
+  "Ensure we offer the correct possibilities for a `defcustom'
+that allows a repeated choice."
+  (should
+   (equal
+    (refine--possible-elements 'refine--possible-choice)
+    '(foo bar baz))))
+
 (defcustom refine--possible-unhandled '(1 2 3)
   "Dummy to make Cask happy."
   :type '(repeat number))


### PR DESCRIPTION
When a custom variable allows for values of type ‘(repeat number)’, ‘-when-let’
would error out since ‘number’ does not match a cons pattern. To guard against
this case, we now use ‘pcase’, which will not error out when a pattern fails to
match.