### PR TITLE
Pretty print in emacs-lisp mode

### DIFF
--- a/refine.el
+++ b/refine.el
@@ -78,6 +78,7 @@ Returns nil if SYMBOL is not a custom variable."
 (defun refine--pretty-format (value)
   "Pretty print VALUE as a string."
   (let ((cl-formatted (with-temp-buffer
+                        (emacs-lisp-mode)
                         (cl-prettyprint value)
                         (s-trim (buffer-string)))))
     (cond ((stringp value)


### PR DESCRIPTION
Try refining a variable with the following value:

``` emacs-lisp
(:columns ((+ivy-rich-buffer-name (:width 30))
           (ivy-rich-switch-buffer-size (:width 7))
           (ivy-rich-switch-buffer-indicators (:width 4
                                                      :face
                                                      error
                                                      :align
                                                      right))
           (ivy-rich-switch-buffer-major-mode (:width 12 :face warning))
           (ivy-rich-switch-buffer-project (:width 15 :face success))
           (ivy-rich-switch-buffer-path (:width (lambda (x)
                                                  (ivy-rich-switch-buffer-shorten-path x
                                                                                       (ivy-rich-minibuffer-width 0.3))))))
          :predicate
          (lambda (cand) (get-buffer cand)))
```

Without emacs-lisp-mode, pretty printing will fail.